### PR TITLE
Adds back param to make `withoutTOMLExtension` return not a function but a string

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
       perSystem = { lib, pkgs, ... }:
         let
           isTOML = file: lib.hasSuffix ".toml" file;
-          withoutTOMLExtension = file: lib.removeSuffix ".toml";
+          withoutTOMLExtension = file: lib.removeSuffix ".toml" file;
           dirEntries =
             lib.attrNames (builtins.readDir "${alacritty-theme}/themes");
           themeFiles = lib.filter isTOML dirEntries;


### PR DESCRIPTION
I made a mistake when cleaning up the function `withoutYAMLExtension` to `withoutTOMLExtension` and accidentally removed the param...my bad...